### PR TITLE
build: integrate Develocity build scans

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,22 @@ pluginManagement {
 }
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("com.gradle.develocity") version "4.4.3"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfUseAgree = "yes"
+        val isCi = System.getenv("CI") != null
+        // Only publish scans from CI; keep local builds from sending data externally.
+        publishing.onlyIf { isCi }
+        if (isCi) {
+            tag("CI")
+            // Ensure the scan finishes uploading before the runner terminates.
+            uploadInBackground = false
+        }
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## Summary

Integrates Develocity Build Scans for build observability across CI runs.

## What's included

- Apply the `com.gradle.develocity` plugin in `settings.gradle.kts`.
- Publish build scans to the public service (`scans.gradle.com`) **only on CI** — local developer builds never send data externally.
- Tag CI builds with `CI` and disable background upload so the scan finishes before the runner terminates.
- Auto-accept the Gradle terms of use for non-interactive publishing.

## Notes

- GitHub Actions sets `CI=true` automatically, so the existing workflows (`pull_request.yml`, `firebase_distribution.yml`) will publish a scan whenever they run Gradle — the scan URL appears in the build log. No workflow changes required.
- Applied to the root `settings.gradle.kts` only; a single scan covers the whole build invocation.

## Verification

- `./gradlew help` → BUILD SUCCESSFUL (plugin resolves and applies; no scan published locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)